### PR TITLE
update edge linewidth to compatible with the released ggplot2 (>=3.4.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
 URL: https://github.com/gaospecial/ggVennDiagram
 License: GPL-3
 Encoding: UTF-8
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.3
 Suggests: 
     testthat (>= 2.1.0),
     knitr,

--- a/R/ggVennDiagram.R
+++ b/R/ggVennDiagram.R
@@ -131,14 +131,35 @@ plot_venn <- function(x,
                       ...){
   venn <- Venn(x)
   data <- process_data(venn)
-  p <- ggplot() +
-    geom_sf(aes_string(fill="count"), data = data@region) +
-    geom_sf(aes_string(color = "id"), data = data@setEdge, show.legend = F,
-            lty = edge_lty, size = edge_size) +
-    geom_sf_text(aes_string(label = "name"), data = data@setLabel,
-                 size = set_size,
-                 color = set_color) +
-    theme_void()
+  p <- ggplot()
+
+  region.params <- list(data = data@region, mapping = aes_string(fill = 'count'))
+
+  edge.params <- list(data = data@setEdge, 
+                      mapping = aes_string(color = 'id'), 
+                      show.legend = FALSE)
+
+  if (utils::packageVersion('ggplot2') >= '3.4.0'){
+    edge.params$linetype <- edge_lty
+    edge.params$linewidth <- edge_size
+  }else{
+    edge.params$lty <- edge_lty
+    edge.params$size <- edge_size
+  }
+
+  text.params <- list(data = data@setLabel, 
+                      mapping = aes_string(label = 'name'),
+                      size = set_size,
+                      color = set_color
+                 )
+
+  region.layer <- do.call('geom_sf', region.params)
+  
+  edge.layer <- do.call('geom_sf', edge.params)
+
+  text.layer <- do.call('geom_sf_text', text.params)
+
+  p <- p + region.layer + edge.layer + text.layer + theme_void()
 
   if (label != "none" & show_intersect == FALSE){
     region_label <- data@region %>%


### PR DESCRIPTION
The `size` of some `geom` in ggplot2 >= (3.4.0) had been replaced with `linewidth`. see the https://github.com/tidyverse/ggplot2/pull/4959. The original `edge_size` parameters did not work to adjust the width of edge. This pr has fixed this issue.

```
> library(ggVennDiagram)
> x <- list(A=1:5,B=2:7,C=3:6,D=4:9)
> p1 <- ggVennDiagram(x)
> p2 <- ggVennDiagram(x, edge_size = 4)
> p1 + p2
```
![捕获](https://user-images.githubusercontent.com/17870644/217495511-fcdb016a-e591-4f2f-a365-e3909dbb35dc.PNG)
